### PR TITLE
Move Controls to hamburger menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ docs/ros.js
 docs/ros.js.map
 
 web/user/**
-.vscode/*.db
+.vscode/*.db*
 **/log
 # Logs
 logs

--- a/src/RenderTest.ts
+++ b/src/RenderTest.ts
@@ -25,7 +25,7 @@ let isTestMenuExpanded: boolean = false;
 let testMenuContainer: GUI.Rectangle | undefined = undefined;
 
 function createTestMenuButton(name: string, text: string, onClick: () => void): GUI.Button {
-  var button = GUI.Button.CreateSimpleButton(name, text);
+  const button = GUI.Button.CreateSimpleButton(name, text);
   button.widthInPixels = 200;
   button.heightInPixels = 28;
   button.color = "white";

--- a/src/RobotScene.ts
+++ b/src/RobotScene.ts
@@ -55,6 +55,7 @@ export class RobotScene {
   private hamburgerButton: GUI.Button | undefined = undefined;
   private menuPanel: GUI.StackPanel | undefined = undefined;
   private menuScrollViewer: GUI.ScrollViewer | undefined = undefined;
+  private menuContainer: GUI.Rectangle | undefined = undefined;
   private isMenuExpanded: boolean = false;
       
 
@@ -377,7 +378,7 @@ export class RobotScene {
   }
   
   createButton(toolbar: GUI.StackPanel, name : string, text : string, scene : BABYLON.Scene, onClick : () => void) {
-    var button = GUI.Button.CreateSimpleButton(name, text);
+    const button = GUI.Button.CreateSimpleButton(name, text);
     button.width = "100px";
     button.height = "20px";
     button.color = "white";
@@ -389,7 +390,7 @@ export class RobotScene {
   }
 
   createMenuButton(name : string, text : string, onClick : () => void) {
-    var button = GUI.Button.CreateSimpleButton(name, text);
+    const button = GUI.Button.CreateSimpleButton(name, text);
     button.widthInPixels = 120;
     button.heightInPixels = 30;
     button.color = "white";
@@ -428,20 +429,20 @@ export class RobotScene {
     this.UILayer.addControl(this.hamburgerButton);
 
     // Create menu panel container
-    const menuContainer = new GUI.Rectangle("menuContainer");
-    menuContainer.widthInPixels = 175;
-    menuContainer.heightInPixels = 400;
-    menuContainer.cornerRadius = 8;
-    menuContainer.color = "white";
-    menuContainer.thickness = 2;
-    menuContainer.background = "rgba(0, 0, 0, 0.6)";
-    menuContainer.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
-    menuContainer.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
-    menuContainer.leftInPixels = 10;
-    menuContainer.topInPixels = 60;
-    menuContainer.isVisible = false;
+    this.menuContainer = new GUI.Rectangle("menuContainer");
+    this.menuContainer.widthInPixels = 175;
+    this.menuContainer.heightInPixels = 400;
+    this.menuContainer.cornerRadius = 8;
+    this.menuContainer.color = "white";
+    this.menuContainer.thickness = 2;
+    this.menuContainer.background = "rgba(0, 0, 0, 0.6)";
+    this.menuContainer.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+    this.menuContainer.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
+    this.menuContainer.leftInPixels = 10;
+    this.menuContainer.topInPixels = 60;
+    this.menuContainer.isVisible = false;
     
-    this.UILayer.addControl(menuContainer);
+    this.UILayer.addControl(this.menuContainer);
 
     // Create scroll viewer for the menu
     this.menuScrollViewer = new GUI.ScrollViewer("menuScrollViewer");
@@ -452,7 +453,7 @@ export class RobotScene {
     this.menuScrollViewer.heightInPixels = 400;
     this.menuScrollViewer.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
     
-    menuContainer.addControl(this.menuScrollViewer);
+    this.menuContainer.addControl(this.menuScrollViewer);
 
     // Create the menu panel (vertical stack)
     this.menuPanel = new GUI.StackPanel("menuPanel");
@@ -467,9 +468,6 @@ export class RobotScene {
 
     // Add all the menu buttons
     this.createMenuButtons();
-
-    // Store reference to container for toggling
-    (this as any).menuContainer = menuContainer;
   }
 
   createMenuButtons() {
@@ -533,10 +531,8 @@ export class RobotScene {
 
   toggleMenu() {
     this.isMenuExpanded = !this.isMenuExpanded;
-    const menuContainer = (this as any).menuContainer;
-    
-    if (menuContainer) {
-      menuContainer.isVisible = this.isMenuExpanded;
+    if (this.menuContainer) {
+      this.menuContainer.isVisible = this.isMenuExpanded;
     }
     
     // Update hamburger button icon

--- a/src/RobotScene.ts
+++ b/src/RobotScene.ts
@@ -50,6 +50,12 @@ export class RobotScene {
   private savedFramingRadius: number = 1;
   private savedFramingAlpha: number = -Math.PI / 3;
   private savedFramingBeta: number = 5 * Math.PI / 12;
+  
+  // Hamburger menu properties
+  private hamburgerButton: GUI.Button | undefined = undefined;
+  private menuPanel: GUI.StackPanel | undefined = undefined;
+  private menuScrollViewer: GUI.ScrollViewer | undefined = undefined;
+  private isMenuExpanded: boolean = false;
       
 
   clearStatus() {
@@ -382,6 +388,163 @@ export class RobotScene {
     return button;
   }
 
+  createMenuButton(name : string, text : string, onClick : () => void) {
+    var button = GUI.Button.CreateSimpleButton(name, text);
+    button.widthInPixels = 120;
+    button.heightInPixels = 30;
+    button.color = "white";
+    button.cornerRadius = 5;
+    button.background = "green";
+    button.fontSize = "12px";
+    button.paddingTopInPixels = 4;
+    button.paddingBottomInPixels = 4;
+    button.onPointerUpObservable.add(onClick);
+    return button;
+  }
+
+  createHamburgerMenu() {
+    if (!this.UILayer) {
+      return;
+    }
+
+    // Create hamburger button
+    this.hamburgerButton = GUI.Button.CreateSimpleButton("hamburgerButton", "☰");
+    this.hamburgerButton.widthInPixels = 40;
+    this.hamburgerButton.heightInPixels = 40;
+    this.hamburgerButton.color = "white";
+    this.hamburgerButton.cornerRadius = 5;
+    this.hamburgerButton.background = "rgba(0, 0, 0, 0.8)";
+    this.hamburgerButton.fontSize = "20px";
+    this.hamburgerButton.fontWeight = "bold";
+    this.hamburgerButton.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+    this.hamburgerButton.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
+    this.hamburgerButton.leftInPixels = 10;
+    this.hamburgerButton.topInPixels = 10;
+    
+    this.hamburgerButton.onPointerUpObservable.add(() => {
+      this.toggleMenu();
+    });
+    
+    this.UILayer.addControl(this.hamburgerButton);
+
+    // Create menu panel container
+    const menuContainer = new GUI.Rectangle("menuContainer");
+    menuContainer.widthInPixels = 175;
+    menuContainer.heightInPixels = 400;
+    menuContainer.cornerRadius = 8;
+    menuContainer.color = "white";
+    menuContainer.thickness = 2;
+    menuContainer.background = "rgba(0, 0, 0, 0.6)";
+    menuContainer.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
+    menuContainer.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
+    menuContainer.leftInPixels = 10;
+    menuContainer.topInPixels = 60;
+    menuContainer.isVisible = false;
+    
+    this.UILayer.addControl(menuContainer);
+
+    // Create scroll viewer for the menu
+    this.menuScrollViewer = new GUI.ScrollViewer("menuScrollViewer");
+    this.menuScrollViewer.thickness = 0;
+    this.menuScrollViewer.color = "transparent";
+    this.menuScrollViewer.background = "transparent";
+    this.menuScrollViewer.widthInPixels = 175;
+    this.menuScrollViewer.heightInPixels = 400;
+    this.menuScrollViewer.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
+    
+    menuContainer.addControl(this.menuScrollViewer);
+
+    // Create the menu panel (vertical stack)
+    this.menuPanel = new GUI.StackPanel("menuPanel");
+    this.menuPanel.isVertical = true;
+    this.menuPanel.spacing = 5;
+    this.menuPanel.paddingTopInPixels = 10;
+    this.menuPanel.paddingBottomInPixels = 10;
+    this.menuPanel.paddingLeftInPixels = 5;
+    this.menuPanel.paddingRightInPixels = 5;
+    
+    this.menuScrollViewer.addControl(this.menuPanel);
+
+    // Add all the menu buttons
+    this.createMenuButtons();
+
+    // Store reference to container for toggling
+    (this as any).menuContainer = menuContainer;
+  }
+
+  createMenuButtons() {
+    if (!this.menuPanel || !this.scene || !this.utilLayer) {
+      return;
+    }
+
+    // Add all the buttons to the menu
+    const jointAxisButton = this.createMenuButton("jointAxisButton", "Joint Axis", () => {
+      this.toggleAxisOnRobot(true, this.scene, this.utilLayer!);
+    });
+    this.menuPanel.addControl(jointAxisButton);
+
+    const linkAxisButton = this.createMenuButton("linkAxisButton", "Link Axis", () => {
+      this.toggleAxisOnRobot(false, this.scene, this.utilLayer!);
+    });
+    this.menuPanel.addControl(linkAxisButton);
+
+    const jointRotationButton = this.createMenuButton("jointRotationButton", "Joint Rotation", () => {
+      this.toggleAxisRotationOnRobot(true, this.UILayer, this.scene, this.utilLayer!);
+    });
+    this.menuPanel.addControl(jointRotationButton);
+
+    const linkRotationButton = this.createMenuButton("linkRotationButton", "Link Rotation", () => {
+      this.toggleAxisRotationOnRobot(false, this.UILayer, this.scene, this.utilLayer!);
+    });
+    this.menuPanel.addControl(linkRotationButton);
+
+    const worldAxisButton = this.createMenuButton("worldAxis", "World Axis", () => {
+      this.toggleWorldAxis();
+    });
+    this.menuPanel.addControl(worldAxisButton);
+
+    const collisionButton = this.createMenuButton("collision", "Collision", () => {
+      this.toggleCollision();
+    });
+    this.menuPanel.addControl(collisionButton);
+
+    const visualsButton = this.createMenuButton("visuals", "Visuals", () => {
+      this.toggleVisuals();
+    });
+    this.menuPanel.addControl(visualsButton);
+
+    const boundingBoxButton = this.createMenuButton("boundingBoxes", "Bounding Boxes", () => {
+      this.toggleBoundingBoxes();
+    });
+    this.menuPanel.addControl(boundingBoxButton);
+
+    const resetCameraButton = this.createMenuButton("resetCamera", "Reset Camera", () => {
+      this.resetCamera();
+    });
+    this.menuPanel.addControl(resetCameraButton);
+
+    const resetButton = this.createMenuButton("reset", "Reset Robot", () => {
+      if (this.currentURDF !== undefined) {
+        this.applyURDF(this.currentURDF);
+      }
+    });
+    this.menuPanel.addControl(resetButton);
+  }
+
+  toggleMenu() {
+    this.isMenuExpanded = !this.isMenuExpanded;
+    const menuContainer = (this as any).menuContainer;
+    
+    if (menuContainer) {
+      menuContainer.isVisible = this.isMenuExpanded;
+    }
+    
+    // Update hamburger button icon
+    if (this.hamburgerButton) {
+      this.hamburgerButton.textBlock!.text = this.isMenuExpanded ? "✕" : "☰";
+    }
+  }
+
 
   makeTextPlane(text : string, color : string, size : number) {
     if (!this.scene) {
@@ -480,17 +643,6 @@ export class RobotScene {
     this.statusLabel.outlineWidth = 2.0;
     this.UILayer.addControl(this.statusLabel);
   
-    var toolbar = new GUI.StackPanel();
-    toolbar.paddingTop = "10px";
-    toolbar.paddingLeft = "10px";
-    toolbar.width = "100%";
-    toolbar.height = "50px";
-    toolbar.fontSize = "14px";
-    toolbar.horizontalAlignment = GUI.Control.HORIZONTAL_ALIGNMENT_LEFT;
-    toolbar.verticalAlignment = GUI.Control.VERTICAL_ALIGNMENT_TOP;
-    toolbar.isVertical = false;
-    this.UILayer.addControl(toolbar);
-  
     // Create a utility layer with specific settings to ensure gizmo visibility
     this.utilLayer = new BABYLON.UtilityLayerRenderer(this.scene);
     //this.utilLayer.utilityLayerScene.autoClearDepthAndStencil = false; // Helps with depth sorting
@@ -503,40 +655,9 @@ export class RobotScene {
     gizmoManager.rotationGizmoEnabled = true;
     
     this.createWorldAxis();
-  
-    this.createButton(toolbar, "jointAxisButton", "Joint Axis", this.scene, () => {
-      this.toggleAxisOnRobot(true, this.scene, this.utilLayer!);
-    });
-  
-    this.createButton(toolbar, "linkAxisButton", "Link Axis", this.scene, () => {
-      this.toggleAxisOnRobot(false, this.scene, this.utilLayer!);
-    });
-  
-    this.createButton(toolbar, "jointRotationButton", "Joint Rotation", this.scene, () => {  
-      this.toggleAxisRotationOnRobot(true, this.UILayer, this.scene, this.utilLayer!);
-    });
-  
-    this.createButton(toolbar, "linkRotationButton", "Link Rotation", this.scene, () => {  
-      this.toggleAxisRotationOnRobot(false, this.UILayer, this.scene, this.utilLayer!);
-    });
-
-    this.createButton(toolbar, "worldAxis", "World Axis", this.scene, () => {  
-      this.toggleWorldAxis();
-    });
-
-    this.createButton(toolbar, "collision", "Collision", this.scene, () => {  
-      this.toggleCollision();
-    });
-
-    this.createButton(toolbar, "visuals", "Visuals", this.scene, () => {  
-      this.toggleVisuals();
-    });
-
-    this.createButton(toolbar, "reset", "Reset", this.scene, () => {  
-      if (this.currentURDF !== undefined) {
-        this.applyURDF(this.currentURDF);
-      }
-    });
+    
+    // Create hamburger menu system
+    this.createHamburgerMenu();
 
     let that = this;
     this.scene.onPointerDown = function castRay() {


### PR DESCRIPTION
The number of controls was getting unwieldy - and often clipping in views. This change introduces a hamburger menu to hide the controls. This does mean multiple clicks to start, but it stays open once clicked. It also scrolls